### PR TITLE
Workaround broken setuptools_scm dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-setup_requires=setuptools_scm
+setup_requires =
+    tomli
+    setuptools_scm
 install_requires =
-    setuptools>=21.0.0
+    setuptools >= 21.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,4 @@ setup(
     name="cardano-clusterlib",
     packages=find_packages(),
     use_scm_version=True,
-    setup_requires=["setuptools_scm"],
 )


### PR DESCRIPTION
See https://github.com/pypa/setuptools_scm/issues/608

Fixes https://github.com/input-output-hk/cardano-clusterlib-py/issues/38