### PR TITLE
Add default value for `_min_change_value`

### DIFF
--- a/cardano_clusterlib/clusterlib.py
+++ b/cardano_clusterlib/clusterlib.py
@@ -320,7 +320,8 @@ class ClusterLib:
 
         self.slots_offset = slots_offset or SLOTS_OFFSETS.get(self.network_magic) or 0
         self.ttl_length = 1000
-        self._min_change_value = 0  # TODO: proper calculation based on `minUTxOValue` needed
+        # TODO: proper calculation based on `utxoCostPerWord` needed
+        self._min_change_value = 1800_000
 
         self.tx_era = tx_era
         self.tx_era_arg = [f"--{self.tx_era.lower()}-era"] if self.tx_era else []


### PR DESCRIPTION
The default value should work for both mainnet and testnet. However
proper calculation based on transaction size and `utxoCostPerWord` is
needed.

See https://github.com/input-output-hk/cardano-clusterlib-py/issues/52