### PR TITLE
Format CLI arguments for logging

### DIFF
--- a/cardano_clusterlib/clusterlib_helpers.py
+++ b/cardano_clusterlib/clusterlib_helpers.py
@@ -2,15 +2,19 @@
 import datetime
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import NamedTuple
 
 from cardano_clusterlib import exceptions
 from cardano_clusterlib import types
 
 LOGGER = logging.getLogger(__name__)
+
+SPECIAL_ARG_CHARS_RE = re.compile("[^A-Za-z0-9/._-]")
 
 
 class EpochInfo(NamedTuple):
@@ -65,6 +69,21 @@ def _check_files_exist(*out_files: types.FileType, clusterlib_obj: "types.Cluste
         out_file = Path(out_file).expanduser()
         if out_file.exists():
             raise exceptions.CLIError(f"The expected file `{out_file}` already exist.")
+
+
+def _format_cli_args(cli_args: List[str]) -> str:
+    """Format CLI arguments for logging.
+
+    Quote arguments with spaces and other "special" characters in them.
+
+    Args:
+        cli_args: List of CLI arguments.
+    """
+    processed_args = []
+    for arg in cli_args:
+        arg = f'"{arg}"' if SPECIAL_ARG_CHARS_RE.search(arg) else arg
+        processed_args.append(arg)
+    return " ".join(processed_args)
 
 
 def _write_cli_log(clusterlib_obj: "types.ClusterLib", command: str) -> None:


### PR DESCRIPTION
Quote arguments with spaces and other "special" characters in them in the same way these would be formatted when entered into command line manually. E.g.

```
cardano-cli transaction build --tx-in "03eee85081ad76948094d3acbaae44fdf725f4998a89b33a0f8ecea65b2af921#1" --tx-out "addr_test1vzhx4xqz6t3qdf3pklgx5m724quqemszjehqm2s5mau5f5gpk0q29+2000000" --change-address addr_test1vp50wj6q0ut0vdqcw0dn79eh8gh0dt5ytq6vm5v0a3h53rq6m4pl2 --out-file tx.body
```