### PR TITLE
Update committee query return type

### DIFF
--- a/cardano_clusterlib/conway_gov_query_group.py
+++ b/cardano_clusterlib/conway_gov_query_group.py
@@ -112,11 +112,9 @@ class ConwayGovQueryGroup:
         )
         return out
 
-    def committee_state(self) -> tp.List[tp.List[tp.Dict[str, tp.Any]]]:
+    def committee_state(self) -> tp.Dict[str, tp.Any]:
         """Get the committee state."""
-        out: tp.List[tp.List[tp.Dict[str, tp.Any]]] = json.loads(
-            self.query_cli(["committee-state"])
-        )
+        out: tp.Dict[str, tp.Any] = json.loads(self.query_cli(["committee-state"]))
         return out
 
     def __repr__(self) -> str:


### PR DESCRIPTION
The structure for querying committee state has changed and now response looks like this:

```
reg_committee_state = cluster.g_conway_governance.query.committee_state()

In [1]: reg_committee_state

Out[1]: 
{'committee': {'keyHash-8176f4b039be7e2b3a31ab4a9a5e802170256e28966ee65de60d1075': {'expiration': None,
   'hotCredsAuthStatus': {'contents': {'keyHash': '14c93febe6db1c1e9d7855197e9c5bbebf0b10016ee3f07c1bff0026'},
    'tag': 'MemberAuthorized'},
   'nextEpochChange': 'NoChangeExpected',
   'status': 'Unrecognized'}},
 'epoch': 23,
 'quorum': 0.0}
```