### PR TITLE
Adds support for proposals with script in transaction group and constitution_script_hash in action group

### DIFF
--- a/cardano_clusterlib/clusterlib.py
+++ b/cardano_clusterlib/clusterlib.py
@@ -32,6 +32,7 @@ from cardano_clusterlib.structs import CCMember
 from cardano_clusterlib.structs import CLIOut
 from cardano_clusterlib.structs import ColdKeyPair
 from cardano_clusterlib.structs import ComplexCert
+from cardano_clusterlib.structs import ComplexProposal
 from cardano_clusterlib.structs import DataForBuild
 from cardano_clusterlib.structs import GenesisKeys
 from cardano_clusterlib.structs import KeyPair
@@ -39,6 +40,7 @@ from cardano_clusterlib.structs import LeadershipSchedule
 from cardano_clusterlib.structs import Mint
 from cardano_clusterlib.structs import OptionalMint
 from cardano_clusterlib.structs import OptionalScriptCerts
+from cardano_clusterlib.structs import OptionalScriptProposals
 from cardano_clusterlib.structs import OptionalScriptTxIn
 from cardano_clusterlib.structs import OptionalScriptVotes
 from cardano_clusterlib.structs import OptionalScriptWithdrawals

--- a/cardano_clusterlib/conway_gov_action_group.py
+++ b/cardano_clusterlib/conway_gov_action_group.py
@@ -136,6 +136,7 @@ class ConwayGovActionGroup:
         anchor_data_hash: str,
         constitution_url: str,
         constitution_hash: str,
+        constitution_script_hash: str = "",
         deposit_return_stake_vkey: str = "",
         deposit_return_stake_vkey_file: tp.Optional[itp.FileType] = None,
         deposit_return_stake_key_hash: str = "",
@@ -170,6 +171,13 @@ class ConwayGovActionGroup:
             "--constitution-hash",
             str(constitution_hash),
         ]
+        if constitution_script_hash:
+            constitution_anchor_args.extend(
+                [
+                    "--constitution-script-hash",
+                    str(constitution_script_hash),
+                ]
+            )
 
         self._clusterlib_obj.cli(
             [

--- a/cardano_clusterlib/structs.py
+++ b/cardano_clusterlib/structs.py
@@ -139,6 +139,24 @@ class ComplexCert:
 
 
 @dataclasses.dataclass(frozen=True, order=True)
+class ComplexProposal:
+    """Data structure for proposal with optional data for Plutus scripts.
+
+    If used for one proposal, it needs to be used for all the other proposals in a given
+    transaction (instead of `TxFiles.proposal_files`). Otherwise, order of proposals
+    cannot be guaranteed.
+    """
+
+    proposal_file: itp.FileType
+    script_file: itp.FileType = ""
+    collaterals: OptionalUTXOData = ()
+    execution_units: tp.Optional[tp.Tuple[int, int]] = None
+    redeemer_file: itp.FileType = ""
+    redeemer_cbor_file: itp.FileType = ""
+    redeemer_value: str = ""
+
+
+@dataclasses.dataclass(frozen=True, order=True)
 class ScriptVote:
     """Data structure for voting that are combined with scripts."""
 
@@ -171,6 +189,8 @@ class Mint:
 OptionalScriptTxIn = tp.Union[tp.List[ScriptTxIn], tp.Tuple[()]]
 # list of `ComplexCert`s, empty list, or empty tuple
 OptionalScriptCerts = tp.Union[tp.List[ComplexCert], tp.Tuple[()]]
+# list of `ComplexProposal`s, empty list, or empty tuple
+OptionalScriptProposals = tp.Union[tp.List[ComplexProposal], tp.Tuple[()]]
 # list of `ScriptWithdrawal`s, empty list, or empty tuple
 OptionalScriptWithdrawals = tp.Union[tp.List[ScriptWithdrawal], tp.Tuple[()]]
 # list of `Mint`s, empty list, or empty tuple
@@ -224,6 +244,7 @@ class TxRawOutput:
     script_withdrawals: OptionalScriptWithdrawals = ()  # Withdrawals that are combined with scripts
     script_votes: OptionalScriptVotes = ()  # Votes that are combined with scripts
     complex_certs: OptionalScriptCerts = ()  # Certificates that are combined with scripts
+    complex_proposals: OptionalScriptProposals = ()  # Proposals that are combined with scripts
     mint: OptionalMint = ()  # Minting data (Tx outputs, script, etc.)
     invalid_hereafter: tp.Optional[int] = None  # Validity interval upper bound
     invalid_before: tp.Optional[int] = None  # Validity interval lower bound

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -145,7 +145,7 @@ class TransactionGroup:
 
         return deposit
 
-    def build_raw_tx_bare(
+    def build_raw_tx_bare(  # noqa: C901
         self,
         out_file: itp.FileType,
         txouts: tp.List[structs.TxOut],
@@ -158,6 +158,7 @@ class TransactionGroup:
         total_collateral_amount: tp.Optional[int] = None,
         mint: structs.OptionalMint = (),
         complex_certs: structs.OptionalScriptCerts = (),
+        complex_proposals: structs.OptionalScriptProposals = (),
         required_signers: itp.OptionalFiles = (),
         required_signer_hashes: tp.Optional[tp.List[str]] = None,
         ttl: tp.Optional[int] = None,
@@ -187,6 +188,8 @@ class TransactionGroup:
             mint: An iterable of `Mint`, specifying script minting data (optional).
             complex_certs: An iterable of `ComplexCert`, specifying certificates script data
                 (optional).
+            complex_proposals: An iterable of `ComplexProposal`, specifying proposal script data
+                (optional).
             required_signers: An iterable of filepaths of the signing keys whose signatures
                 are required (optional).
             required_signer_hashes: A list of hashes of the signing keys whose signatures
@@ -211,6 +214,12 @@ class TransactionGroup:
             LOGGER.warning(
                 "Mixing `tx_files.certificate_files` and `complex_certs`, "
                 "certs may come in unexpected order."
+            )
+
+        if tx_files.proposal_files and complex_proposals:
+            LOGGER.warning(
+                "Mixing `tx_files.proposal_files` and `complex_proposals`, "
+                "proposals may come in unexpected order."
             )
 
         out_file = pl.Path(out_file)
@@ -257,6 +266,7 @@ class TransactionGroup:
             script_txins=script_txins,
             mint=mint,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             script_withdrawals=script_withdrawals,
             script_votes=script_votes,
             for_build=False,
@@ -326,6 +336,7 @@ class TransactionGroup:
             script_withdrawals=script_withdrawals,
             script_votes=script_votes,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             mint=mint,
             invalid_hereafter=invalid_hereafter or ttl,
             invalid_before=invalid_before,
@@ -358,6 +369,7 @@ class TransactionGroup:
         mint: structs.OptionalMint = (),
         tx_files: tp.Optional[structs.TxFiles] = None,
         complex_certs: structs.OptionalScriptCerts = (),
+        complex_proposals: structs.OptionalScriptProposals = (),
         fee: int = 0,
         required_signers: itp.OptionalFiles = (),
         required_signer_hashes: tp.Optional[tp.List[str]] = None,
@@ -389,6 +401,8 @@ class TransactionGroup:
             tx_files: A `structs.TxFiles` tuple containing files needed for the transaction
                 (optional).
             complex_certs: An iterable of `ComplexCert`, specifying certificates script data
+                (optional).
+            complex_proposals: An iterable of `ComplexProposal`, specifying proposals script data
                 (optional).
             fee: A fee amount (optional).
             required_signers: An iterable of filepaths of the signing keys whose signatures
@@ -427,6 +441,7 @@ class TransactionGroup:
             mint=mint,
             tx_files=tx_files,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             fee=fee,
             withdrawals=withdrawals,
             script_withdrawals=script_withdrawals,
@@ -455,6 +470,7 @@ class TransactionGroup:
             total_collateral_amount=total_collateral_amount,
             mint=mint,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             required_signers=required_signers,
             required_signer_hashes=required_signer_hashes,
             withdrawals=collected_data.withdrawals,
@@ -532,6 +548,7 @@ class TransactionGroup:
         mint: structs.OptionalMint = (),
         tx_files: tp.Optional[structs.TxFiles] = None,
         complex_certs: structs.OptionalScriptCerts = (),
+        complex_proposals: structs.OptionalScriptProposals = (),
         required_signers: itp.OptionalFiles = (),
         required_signer_hashes: tp.Optional[tp.List[str]] = None,
         ttl: tp.Optional[int] = None,
@@ -564,6 +581,8 @@ class TransactionGroup:
             tx_files: A `structs.TxFiles` tuple containing files needed for the transaction
                 (optional).
             complex_certs: An iterable of `ComplexCert`, specifying certificates script data
+                (optional).
+            complex_proposals: An iterable of `ComplexProposal`, specifying proposal script data
                 (optional).
             required_signers: An iterable of filepaths of the signing keys whose signatures
                 are required (optional).
@@ -612,6 +631,7 @@ class TransactionGroup:
             mint=mint,
             tx_files=tx_files,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             required_signers=required_signers,
             required_signer_hashes=required_signer_hashes,
             fee=self.min_fee,
@@ -739,6 +759,7 @@ class TransactionGroup:
         mint: structs.OptionalMint = (),
         tx_files: tp.Optional[structs.TxFiles] = None,
         complex_certs: structs.OptionalScriptCerts = (),
+        complex_proposals: structs.OptionalScriptProposals = (),
         change_address: str = "",
         fee_buffer: tp.Optional[int] = None,
         required_signers: itp.OptionalFiles = (),
@@ -774,6 +795,8 @@ class TransactionGroup:
             tx_files: A `structs.TxFiles` tuple containing files needed for the transaction
                 (optional).
             complex_certs: An iterable of `ComplexCert`, specifying certificates script data
+                (optional).
+            complex_proposals: An iterable of `ComplexProposal`, specifying proposal script data
                 (optional).
             change_address: A string with address where ADA in excess of the transaction fee
                 will go to (`src_address` by default).
@@ -819,6 +842,11 @@ class TransactionGroup:
                 "Mixing `tx_files.certificate_files` and `complex_certs`, "
                 "certs may come in unexpected order."
             )
+        if tx_files.proposal_files and complex_proposals:
+            LOGGER.warning(
+                "Mixing `tx_files.proposal_files` and `complex_proposals`, "
+                "proposals may come in unexpected order."
+            )
 
         destination_dir = pl.Path(destination_dir).expanduser()
 
@@ -834,6 +862,7 @@ class TransactionGroup:
             mint=mint,
             tx_files=tx_files,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             fee=fee_buffer or 0,
             withdrawals=withdrawals,
             script_withdrawals=script_withdrawals,
@@ -877,6 +906,7 @@ class TransactionGroup:
             script_txins=script_txins,
             mint=mint,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             script_withdrawals=collected_data.script_withdrawals,
             script_votes=script_votes,
             for_build=True,
@@ -946,6 +976,7 @@ class TransactionGroup:
             script_withdrawals=collected_data.script_withdrawals,
             script_votes=script_votes,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             mint=mint,
             invalid_hereafter=invalid_hereafter,
             invalid_before=invalid_before,
@@ -1167,6 +1198,7 @@ class TransactionGroup:
         mint: structs.OptionalMint = (),
         tx_files: tp.Optional[structs.TxFiles] = None,
         complex_certs: structs.OptionalScriptCerts = (),
+        complex_proposals: structs.OptionalScriptProposals = (),
         fee: tp.Optional[int] = None,
         required_signers: itp.OptionalFiles = (),
         required_signer_hashes: tp.Optional[tp.List[str]] = None,
@@ -1207,6 +1239,8 @@ class TransactionGroup:
             tx_files: A `structs.TxFiles` tuple containing files needed for the transaction
                 (optional).
             complex_certs: An iterable of `ComplexCert`, specifying certificates script data
+                (optional).
+            complex_proposals: An iterable of `ComplexProposal`, specifying proposal script data
                 (optional).
             fee: A fee amount (optional).
             required_signers: An iterable of filepaths of the signing keys whose signatures
@@ -1258,6 +1292,7 @@ class TransactionGroup:
                 mint=mint,
                 tx_files=tx_files,
                 complex_certs=complex_certs,
+                complex_proposals=complex_proposals,
                 required_signers=required_signers,
                 required_signer_hashes=required_signer_hashes,
                 withdrawals=withdrawals,
@@ -1285,6 +1320,7 @@ class TransactionGroup:
             mint=mint,
             tx_files=tx_files,
             complex_certs=complex_certs,
+            complex_proposals=complex_proposals,
             fee=fee,
             required_signers=required_signers,
             required_signer_hashes=required_signer_hashes,
@@ -1398,6 +1434,7 @@ class TransactionGroup:
         mint: structs.OptionalMint = (),
         tx_files: tp.Optional[structs.TxFiles] = None,
         complex_certs: structs.OptionalScriptCerts = (),
+        complex_proposals: structs.OptionalScriptProposals = (),
         change_address: str = "",
         fee_buffer: tp.Optional[int] = None,
         required_signers: itp.OptionalFiles = (),
@@ -1432,6 +1469,8 @@ class TransactionGroup:
             tx_files: A `structs.TxFiles` tuple containing files needed for the transaction
                 (optional).
             complex_certs: An iterable of `ComplexCert`, specifying certificates script data
+                (optional).
+            complex_proposals: An iterable of `ComplexProposal`, specifying proposal script data
                 (optional).
             change_address: A string with address where ADA in excess of the transaction fee
                 will go to (`src_address` by default).


### PR DESCRIPTION
This PR adds support for creating an action file with constitution_script_hash in create_constitution function inside the Conway gov action group. And adds support for the proposal, which requires a constitutional script for the transaction.

Optional `ComplexProposal`, similar to other data structures such as `ComplexCert`, is used to obtain the required script and redeemer value for the proposal file when building the transaction with build_tx or build_raw_tx.