### PR TITLE
Add treasury donation for build tx command

### DIFF
--- a/cardano_clusterlib/structs.py
+++ b/cardano_clusterlib/structs.py
@@ -248,6 +248,8 @@ class TxRawOutput:
     mint: OptionalMint = ()  # Minting data (Tx outputs, script, etc.)
     invalid_hereafter: tp.Optional[int] = None  # Validity interval upper bound
     invalid_before: tp.Optional[int] = None  # Validity interval lower bound
+    current_treasury_value: tp.Optional[int] = None  # Current treasury value
+    treasury_donation: tp.Optional[int] = None  # Amount of funds that will be donated to treasury
     withdrawals: OptionalTxOuts = ()  # All withdrawals (including those combined with scripts)
     change_address: str = ""  # Address for change
     return_collateral_txouts: OptionalTxOuts = ()  # Tx outputs for returning collateral

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -899,6 +899,7 @@ class TransactionGroup:
             withdrawals=withdrawals,
             script_withdrawals=script_withdrawals,
             deposit=deposit,
+            treasury_donation=treasury_donation,
             lovelace_balanced=True,
             skip_asset_balancing=skip_asset_balancing,
         )

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -218,7 +218,7 @@ class TransactionGroup:
             msg = (
                 "Both `treasury_donation` and `current_treasury_value` must be specified together."
             )
-            raise ValueError(msg)
+            raise AssertionError(msg)
 
         if tx_files.certificate_files and complex_certs:
             LOGGER.warning(

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -447,12 +447,6 @@ class TransactionGroup:
             structs.TxRawOutput: A tuple with transaction output details.
         """
         # pylint: disable=too-many-arguments
-        if (treasury_donation is not None) != (current_treasury_value is not None):
-            msg = (
-                "Both `treasury_donation` and `current_treasury_value` must be specified together."
-            )
-            raise ValueError(msg)
-
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{tx_name}_tx.body"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -641,12 +635,6 @@ class TransactionGroup:
             int: An estimated fee.
         """
         # pylint: disable=too-many-arguments
-        if (treasury_donation is not None) != (current_treasury_value is not None):
-            msg = (
-                "Both `treasury_donation` and `current_treasury_value` must be specified together."
-            )
-            raise ValueError(msg)
-
         tx_files = tx_files or structs.TxFiles()
         tx_name = f"{tx_name}_estimate"
 

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -167,6 +167,8 @@ class TransactionGroup:
         script_votes: structs.OptionalScriptVotes = (),
         invalid_hereafter: tp.Optional[int] = None,
         invalid_before: tp.Optional[int] = None,
+        current_treasury_value: tp.Optional[int] = None,
+        treasury_donation: tp.Optional[int] = None,
         script_valid: bool = True,
         join_txouts: bool = True,
     ) -> structs.TxRawOutput:
@@ -202,6 +204,8 @@ class TransactionGroup:
             script_votes: An iterable of `ScriptVote`, specifying vote script data (optional).
             invalid_hereafter: A last block when the transaction is still valid (optional).
             invalid_before: A first block when the transaction is valid (optional).
+            current_treasury_value: The current treasury value (optional).
+            treasury_donation: A donation to the treasury to perform (optional).
             script_valid: A bool indicating that the script is valid (True by default).
             join_txouts: A bool indicating whether to aggregate transaction outputs
                 by payment address (True by default).
@@ -210,6 +214,12 @@ class TransactionGroup:
             structs.TxRawOutput: A tuple with transaction output details.
         """
         # pylint: disable=too-many-arguments,too-many-branches,too-many-locals,too-many-statements
+        if (treasury_donation is not None) != (current_treasury_value is not None):
+            msg = (
+                "Both `treasury_donation` and `current_treasury_value` must be specified together."
+            )
+            raise ValueError(msg)
+
         if tx_files.certificate_files and complex_certs:
             LOGGER.warning(
                 "Mixing `tx_files.certificate_files` and `complex_certs`, "
@@ -251,6 +261,11 @@ class TransactionGroup:
         elif ttl is not None:
             # `--ttl` and `--invalid-hereafter` are the same
             misc_args.extend(["--ttl", str(ttl)])
+
+        if current_treasury_value is not None:
+            misc_args.extend(["--current-treasury-value", str(current_treasury_value)])
+        if treasury_donation is not None:
+            misc_args.extend(["--treasury-donation", str(treasury_donation)])
 
         if not script_valid:
             misc_args.append("--script-invalid")
@@ -340,6 +355,8 @@ class TransactionGroup:
             mint=mint,
             invalid_hereafter=invalid_hereafter or ttl,
             invalid_before=invalid_before,
+            current_treasury_value=current_treasury_value,
+            treasury_donation=treasury_donation,
             withdrawals=withdrawals,
             return_collateral_txouts=return_collateral_txouts,
             total_collateral_amount=total_collateral_amount,
@@ -378,6 +395,8 @@ class TransactionGroup:
         script_withdrawals: structs.OptionalScriptWithdrawals = (),
         script_votes: structs.OptionalScriptVotes = (),
         deposit: tp.Optional[int] = None,
+        current_treasury_value: tp.Optional[int] = None,
+        treasury_donation: tp.Optional[int] = None,
         invalid_hereafter: tp.Optional[int] = None,
         invalid_before: tp.Optional[int] = None,
         join_txouts: bool = True,
@@ -416,6 +435,8 @@ class TransactionGroup:
                 data (optional).
             script_votes: An iterable of `ScriptVote`, specifying vote script data (optional).
             deposit: A deposit amount needed by the transaction (optional).
+            current_treasury_value: The current treasury value (optional).
+            treasury_donation: A donation to the treasury to perform (optional).
             invalid_hereafter: A last block when the transaction is still valid (optional).
             invalid_before: A first block when the transaction is valid (optional).
             join_txouts: A bool indicating whether to aggregate transaction outputs
@@ -426,6 +447,12 @@ class TransactionGroup:
             structs.TxRawOutput: A tuple with transaction output details.
         """
         # pylint: disable=too-many-arguments
+        if (treasury_donation is not None) != (current_treasury_value is not None):
+            msg = (
+                "Both `treasury_donation` and `current_treasury_value` must be specified together."
+            )
+            raise ValueError(msg)
+
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{tx_name}_tx.body"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -446,6 +473,7 @@ class TransactionGroup:
             withdrawals=withdrawals,
             script_withdrawals=script_withdrawals,
             deposit=deposit,
+            treasury_donation=treasury_donation,
         )
 
         if (
@@ -478,6 +506,8 @@ class TransactionGroup:
             script_votes=script_votes,
             invalid_hereafter=invalid_hereafter or ttl,
             invalid_before=invalid_before,
+            current_treasury_value=current_treasury_value,
+            treasury_donation=treasury_donation,
             join_txouts=join_txouts,
         )
 
@@ -556,6 +586,8 @@ class TransactionGroup:
         script_withdrawals: structs.OptionalScriptWithdrawals = (),
         script_votes: structs.OptionalScriptVotes = (),
         deposit: tp.Optional[int] = None,
+        current_treasury_value: tp.Optional[int] = None,
+        treasury_donation: tp.Optional[int] = None,
         invalid_hereafter: tp.Optional[int] = None,
         invalid_before: tp.Optional[int] = None,
         witness_count_add: int = 0,
@@ -595,6 +627,8 @@ class TransactionGroup:
                 data (optional).
             script_votes: An iterable of `ScriptVote`, specifying vote script data (optional).
             deposit: A deposit amount needed by the transaction (optional).
+            current_treasury_value: The current treasury value (optional).
+            treasury_donation: A donation to the treasury to perform (optional).
             invalid_hereafter: A last block when the transaction is still valid (optional).
             invalid_before: A first block when the transaction is valid (optional).
             witness_count_add: A number of witnesses to add - workaround to make the fee
@@ -607,6 +641,12 @@ class TransactionGroup:
             int: An estimated fee.
         """
         # pylint: disable=too-many-arguments
+        if (treasury_donation is not None) != (current_treasury_value is not None):
+            msg = (
+                "Both `treasury_donation` and `current_treasury_value` must be specified together."
+            )
+            raise ValueError(msg)
+
         tx_files = tx_files or structs.TxFiles()
         tx_name = f"{tx_name}_estimate"
 
@@ -641,6 +681,8 @@ class TransactionGroup:
             invalid_hereafter=invalid_hereafter or ttl,
             invalid_before=invalid_before,
             deposit=deposit,
+            current_treasury_value=current_treasury_value,
+            treasury_donation=treasury_donation,
             join_txouts=join_txouts,
             destination_dir=destination_dir,
         )
@@ -768,6 +810,7 @@ class TransactionGroup:
         script_withdrawals: structs.OptionalScriptWithdrawals = (),
         script_votes: structs.OptionalScriptVotes = (),
         deposit: tp.Optional[int] = None,
+        treasury_donation: tp.Optional[int] = None,
         invalid_hereafter: tp.Optional[int] = None,
         invalid_before: tp.Optional[int] = None,
         witness_override: tp.Optional[int] = None,
@@ -810,6 +853,7 @@ class TransactionGroup:
                 data (optional).
             script_votes: An iterable of `ScriptVote`, specifying vote script data (optional).
             deposit: A deposit amount needed by the transaction (optional).
+            treasury_donation: A donation to the treasury to perform (optional).
             invalid_hereafter: A last block when the transaction is still valid (optional).
             invalid_before: A first block when the transaction is valid (optional).
             witness_override: An integer indicating real number of witnesses. Can be used to fix
@@ -891,6 +935,9 @@ class TransactionGroup:
             misc_args.extend(["--invalid-before", str(invalid_before)])
         if invalid_hereafter is not None:
             misc_args.extend(["--invalid-hereafter", str(invalid_hereafter)])
+
+        if treasury_donation is not None:
+            misc_args.extend(["--treasury-donation", str(treasury_donation)])
 
         if not script_valid:
             misc_args.append("--script-invalid")
@@ -980,6 +1027,7 @@ class TransactionGroup:
             mint=mint,
             invalid_hereafter=invalid_hereafter,
             invalid_before=invalid_before,
+            treasury_donation=treasury_donation,
             withdrawals=collected_data.withdrawals,
             change_address=change_address or src_address,
             return_collateral_txouts=return_collateral_txouts,

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -1244,6 +1244,8 @@ class TransactionGroup:
         script_withdrawals: structs.OptionalScriptWithdrawals = (),
         script_votes: structs.OptionalScriptVotes = (),
         deposit: tp.Optional[int] = None,
+        current_treasury_value: tp.Optional[int] = None,
+        treasury_donation: tp.Optional[int] = None,
         invalid_hereafter: tp.Optional[int] = None,
         invalid_before: tp.Optional[int] = None,
         witness_count_add: int = 0,
@@ -1291,6 +1293,8 @@ class TransactionGroup:
                 data (optional).
             script_votes: An iterable of `ScriptVote`, specifying vote script data (optional).
             deposit: A deposit amount needed by the transaction (optional).
+            current_treasury_value: The current treasury value (optional).
+            treasury_donation: A donation to the treasury to perform (optional).
             invalid_hereafter: A last block when the transaction is still valid (optional).
             invalid_before: A first block when the transaction is valid (optional).
             witness_count_add: A number of witnesses to add - workaround to make the fee
@@ -1335,6 +1339,8 @@ class TransactionGroup:
                 withdrawals=withdrawals,
                 script_withdrawals=script_withdrawals,
                 deposit=deposit,
+                current_treasury_value=current_treasury_value,
+                treasury_donation=treasury_donation,
                 invalid_hereafter=invalid_hereafter or ttl,
                 witness_count_add=witness_count_add,
                 join_txouts=join_txouts,
@@ -1365,6 +1371,8 @@ class TransactionGroup:
             script_withdrawals=script_withdrawals,
             script_votes=script_votes,
             deposit=deposit,
+            current_treasury_value=current_treasury_value,
+            treasury_donation=treasury_donation,
             invalid_hereafter=invalid_hereafter or ttl,
             invalid_before=invalid_before,
             join_txouts=join_txouts,


### PR DESCRIPTION
Add support for treasury donations.

- adds `--treasury-donation` to `transaction build`
- adds `--current-treasury-value` and `--treasury-donation` to `transaction build-raw`

In case of `transaction build-raw` donation must be passed together with current treasury value.