### PR TITLE
chore: update ruff-pre-commit to v0.6.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.5.5
+  rev: v0.6.3
   hooks:
     - id: ruff
       args: [ --fix ]


### PR DESCRIPTION
Updated the ruff-pre-commit hook from version v0.5.5 to v0.6.3 in the .pre-commit-config.yaml file. This ensures we are using the latest features and fixes provided by the ruff-pre-commit tool.