### PR TITLE
feat: use the 'legacy' group for 'genesis' and 'governance'

### DIFF
--- a/cardano_clusterlib/genesis_group.py
+++ b/cardano_clusterlib/genesis_group.py
@@ -19,6 +19,7 @@ class GenesisGroup:
 
         self._genesis_keys: tp.Optional[structs.GenesisKeys] = None
         self._genesis_utxo_addr: str = ""
+        self._cli_args = ("cardano-cli", "legacy", "genesis")
 
     @property
     def genesis_keys(self) -> structs.GenesisKeys:
@@ -94,14 +95,15 @@ class GenesisGroup:
 
         self._clusterlib_obj.cli(
             [
-                "genesis",
+                *self._cli_args,
                 "initial-addr",
                 *self._clusterlib_obj.magic_args,
                 "--verification-key-file",
                 str(vkey_file),
                 "--out-file",
                 str(out_file),
-            ]
+            ],
+            add_default_args=False,
         )
 
         helpers._check_outfiles(out_file)
@@ -118,11 +120,12 @@ class GenesisGroup:
         """
         cli_out = self._clusterlib_obj.cli(
             [
-                "genesis",
+                *self._cli_args,
                 "key-hash",
                 "--verification-key-file",
                 str(vkey_file),
-            ]
+            ],
+            add_default_args=False,
         )
 
         return cli_out.stdout.rstrip().decode("ascii")

--- a/cardano_clusterlib/governance_group.py
+++ b/cardano_clusterlib/governance_group.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 class GovernanceGroup:
     def __init__(self, clusterlib_obj: "itp.ClusterLib") -> None:
         self._clusterlib_obj = clusterlib_obj
+        self._cli_args = ("cardano-cli", "legacy", "governance")
 
     def gen_update_proposal(
         self,
@@ -40,7 +41,7 @@ class GovernanceGroup:
 
         self._clusterlib_obj.cli(
             [
-                "governance",
+                *self._cli_args,
                 "create-update-proposal",
                 *cli_args,
                 "--out-file",
@@ -51,7 +52,8 @@ class GovernanceGroup:
                     "--genesis-verification-key-file",
                     self._clusterlib_obj.g_genesis.genesis_keys.genesis_vkeys,
                 ),
-            ]
+            ],
+            add_default_args=False,
         )
 
         helpers._check_outfiles(out_file)
@@ -79,14 +81,15 @@ class GovernanceGroup:
 
         self._clusterlib_obj.cli(
             [
-                "governance",
+                *self._cli_args,
                 "create-mir-certificate",
                 "transfer-to-treasury",
                 "--transfer",
                 str(transfer),
                 "--out-file",
                 str(out_file),
-            ]
+            ],
+            add_default_args=False,
         )
 
         helpers._check_outfiles(out_file)
@@ -114,14 +117,15 @@ class GovernanceGroup:
 
         self._clusterlib_obj.cli(
             [
-                "governance",
+                *self._cli_args,
                 "create-mir-certificate",
                 "transfer-to-rewards",
                 "--transfer",
                 str(transfer),
                 "--out-file",
                 str(out_file),
-            ]
+            ],
+            add_default_args=False,
         )
 
         helpers._check_outfiles(out_file)
@@ -154,7 +158,7 @@ class GovernanceGroup:
 
         self._clusterlib_obj.cli(
             [
-                "governance",
+                *self._cli_args,
                 "create-mir-certificate",
                 "stake-addresses",
                 f"--{funds_src}",
@@ -164,7 +168,8 @@ class GovernanceGroup:
                 str(reward),
                 "--out-file",
                 str(out_file),
-            ]
+            ],
+            add_default_args=False,
         )
 
         helpers._check_outfiles(out_file)


### PR DESCRIPTION
Use the 'legacy' CLI group for commands that no longer work in Conway era.