### PR TITLE
refactor: remove deprecated tx_era parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cluster.g_query.get_utxo(dst_addr.address)
 from cardano_clusterlib import clusterlib
 
 # instantiate `ClusterLib`
-cluster = clusterlib.ClusterLib(state_dir="path/to/cluster/state_dir", tx_era="babbage")
+cluster = clusterlib.ClusterLib(state_dir="path/to/cluster/state_dir")
 
 # source address - for funding
 src_address = "addr_test1vpst87uzwafqkxumyf446zr2jsyn44cfpu9fe8yqanyuh6glj2hkl"

--- a/cardano_clusterlib/consts.py
+++ b/cardano_clusterlib/consts.py
@@ -33,8 +33,8 @@ class Eras(enum.Enum):
     ALONZO: int = 6
     BABBAGE: int = 8
     CONWAY: int = 9
-    DEFAULT: int = BABBAGE
-    LATEST: int = BABBAGE
+    DEFAULT: int = CONWAY
+    LATEST: int = CONWAY
 
 
 class MultiSigTypeArgs:


### PR DESCRIPTION
The tx_era parameter has been removed from the ClusterLib class and related methods. Updated documentation and internal logic to reflect these changes.