### PR TITLE
refactor: remove deprecated methods and warnings

### DIFF
--- a/cardano_clusterlib/address_group.py
+++ b/cardano_clusterlib/address_group.py
@@ -4,7 +4,6 @@ import json
 import logging
 import pathlib as pl
 import typing as tp
-import warnings
 
 from cardano_clusterlib import clusterlib_helpers
 from cardano_clusterlib import helpers
@@ -165,26 +164,6 @@ class AddressGroup:
             .decode("utf-8")
         )
         return structs.AddressInfo(**addr_dict)
-
-    def gen_script_addr(
-        self, addr_name: str, script_file: itp.FileType, destination_dir: itp.FileType = "."
-    ) -> str:
-        """Generate a script address.
-
-        Args:
-            addr_name: A name of payment address.
-            script_file: A path to corresponding script file.
-            destination_dir: A path to directory for storing artifacts (optional).
-
-        Returns:
-            str: A generated script address.
-        """
-        warnings.warn(
-            "`gen_script_addr` deprecated by `gen_payment_addr`", DeprecationWarning, stacklevel=2
-        )
-        return self.gen_payment_addr(
-            addr_name=addr_name, payment_script_file=script_file, destination_dir=destination_dir
-        )
 
     def gen_payment_addr_and_keys(
         self,

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -5,7 +5,6 @@ import json
 import logging
 import pathlib as pl
 import typing as tp
-import warnings
 
 from packaging import version
 
@@ -701,42 +700,6 @@ class TransactionGroup:
         )
 
         return fee
-
-    def calculate_min_value(
-        self,
-        multi_assets: tp.List[structs.TxOut],
-    ) -> structs.Value:
-        """Calculate the minimum value in for a transaction.
-
-        This was replaced by `calculate_min_req_utxo` for node 1.29.0+.
-
-        Args:
-            multi_assets: A list of `TxOuts`, specifying multi-assets.
-
-        Returns:
-            structs.Value: A tuple describing the value.
-        """
-        warnings.warn(
-            "deprecated by `calculate_min_req_utxo` for node 1.29.0+",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        ma_records = [f"{m.amount} {m.coin}" for m in multi_assets]
-        ma_args = ["--multi-asset", "+".join(ma_records)] if ma_records else []
-
-        self._clusterlib_obj.create_pparams_file()
-        stdout = self._clusterlib_obj.cli(
-            [
-                "transaction",
-                "calculate-min-value",
-                "--protocol-params-file",
-                str(self._clusterlib_obj.pparams_file),
-                *ma_args,
-            ]
-        ).stdout
-        coin, value = stdout.decode().split()
-        return structs.Value(value=int(value), coin=coin)
 
     def calculate_min_req_utxo(
         self,


### PR DESCRIPTION
This commit removes the deprecated methods `gen_script_addr` from `address_group.py` and `calculate_min_value` from `transaction_group.py`. Additionally, it removes the associated warnings related to these methods.