### PR TITLE
refactor: update command era handling in ClusterLib

### DIFF
--- a/cardano_clusterlib/clusterlib.py
+++ b/cardano_clusterlib/clusterlib.py
@@ -6,14 +6,15 @@ Import everything that used to be available here for backwards compatibility.
 # pylint: disable=unused-import
 # flake8: noqa
 from cardano_clusterlib.clusterlib_klass import ClusterLib
+from cardano_clusterlib.consts import CommandEras
 from cardano_clusterlib.consts import DEFAULT_COIN
 from cardano_clusterlib.consts import Eras
 from cardano_clusterlib.consts import MAINNET_MAGIC
 from cardano_clusterlib.consts import MultiSigTypeArgs
 from cardano_clusterlib.consts import MultiSlotTypeArgs
 from cardano_clusterlib.consts import Protocols
-from cardano_clusterlib.consts import ScriptTypes
 from cardano_clusterlib.consts import SLOTS_OFFSETS
+from cardano_clusterlib.consts import ScriptTypes
 from cardano_clusterlib.consts import Votes
 from cardano_clusterlib.coverage import record_cli_coverage
 from cardano_clusterlib.exceptions import CLIError

--- a/cardano_clusterlib/clusterlib_klass.py
+++ b/cardano_clusterlib/clusterlib_klass.py
@@ -51,15 +51,20 @@ class ClusterLib:
         protocol: str = consts.Protocols.CARDANO,
         slots_offset: int = 0,
         socket_path: itp.FileType = "",
-        command_era: str = "latest",
+        command_era: str = consts.CommandEras.LATEST,
     ):
         # pylint: disable=too-many-statements
+        try:
+            self.command_era = getattr(consts.CommandEras, command_era.upper())
+        except AttributeError as excp:
+            msg = f"Unknown command era `{command_era}`."
+            raise exceptions.CLIError(msg) from excp
+
         self.cluster_id = 0  # can be used for identifying cluster instance
         self.cli_coverage: dict = {}
         self._rand_str = helpers.get_rand_str(4)
         self._cli_log = ""
         self.protocol = protocol
-        self.command_era = command_era.lower()
         self.era_in_use = (
             consts.Eras.__members__.get(command_era.upper()) or consts.Eras["DEFAULT"]
         ).name.lower()
@@ -248,8 +253,7 @@ class ClusterLib:
 
         if add_default_args:
             cli_args_strs_all.insert(0, "cardano-cli")
-            if self.command_era:
-                cli_args_strs_all.insert(1, self.command_era)
+            cli_args_strs_all.insert(1, self.command_era)
 
         cli_args_strs = [arg for arg in cli_args_strs_all if arg != consts.SUBCOMMAND_MARK]
 

--- a/cardano_clusterlib/consts.py
+++ b/cardano_clusterlib/consts.py
@@ -20,6 +20,16 @@ SLOTS_OFFSETS: tp.Final[tp.Dict[int, int]] = {
 SUBCOMMAND_MARK: tp.Final[str] = "SUBCOMMAND"
 
 
+class CommandEras:
+    SHELLEY: tp.Final[str] = "shelley"
+    ALLEGRA: tp.Final[str] = "allegra"
+    MARY: tp.Final[str] = "mary"
+    ALONZO: tp.Final[str] = "alonzo"
+    BABBAGE: tp.Final[str] = "babbage"
+    CONWAY: tp.Final[str] = "conway"
+    LATEST: tp.Final[str] = "latest"
+
+
 class Protocols:
     CARDANO: tp.Final[str] = "cardano"
     SHELLEY: tp.Final[str] = "shelley"

--- a/cardano_clusterlib/stake_address_group.py
+++ b/cardano_clusterlib/stake_address_group.py
@@ -292,10 +292,6 @@ class StakeAddressGroup:
         out_file = destination_dir / f"{addr_name}_stake_deleg.cert"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
 
-        command_name = "delegation-certificate"
-        if self._clusterlib_obj.command_era:
-            command_name = "stake-delegation-certificate"
-
         stake_key_args = self._get_stake_vkey_args(
             stake_vkey=stake_vkey,
             stake_vkey_file=stake_vkey_file,
@@ -311,7 +307,7 @@ class StakeAddressGroup:
         self._clusterlib_obj.cli(
             [
                 "stake-address",
-                command_name,
+                "stake-delegation-certificate",
                 *stake_key_args,
                 *pool_key_args,
                 "--out-file",

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -328,7 +328,7 @@ class TransactionGroup:
             misc_args.append("--json-metadata-detailed-schema")
 
         proposal_file_argname = txtools.get_proposal_file_argname(
-            command_era=self._clusterlib_obj.command_era
+            era_in_use=self._clusterlib_obj.era_in_use
         )
 
         cli_args = [
@@ -726,28 +726,15 @@ class TransactionGroup:
             )
             raise AssertionError(msg)
 
-        era = self._clusterlib_obj.g_query.get_era().lower()
-        era_upper = era.upper()
-        command_era_args = []
-        if (
-            self._clusterlib_obj.command_era
-            or (era_upper not in consts.Eras.__members__)
-            or consts.Eras[era_upper].value >= consts.Eras.CONWAY.value
-        ):
-            command_era_args = [era]
-
         self._clusterlib_obj.create_pparams_file()
         stdout = self._clusterlib_obj.cli(
             [
-                "cardano-cli",
-                *command_era_args,
                 "transaction",
                 "calculate-min-required-utxo",
                 "--protocol-params-file",
                 str(self._clusterlib_obj.pparams_file),
                 *txout_args,
-            ],
-            add_default_args=False,
+            ]
         ).stdout
         coin, value = stdout.decode().split()
         return structs.Value(value=int(value), coin=coin)
@@ -941,7 +928,7 @@ class TransactionGroup:
             misc_args.append("--json-metadata-detailed-schema")
 
         proposal_file_argname = txtools.get_proposal_file_argname(
-            command_era=self._clusterlib_obj.command_era
+            era_in_use=self._clusterlib_obj.era_in_use
         )
 
         cli_args = [

--- a/cardano_clusterlib/txtools.py
+++ b/cardano_clusterlib/txtools.py
@@ -1283,11 +1283,11 @@ def _get_script_args(  # noqa: C901
     return grouped_args
 
 
-def get_proposal_file_argname(command_era: str = "") -> str:
+def get_proposal_file_argname(era_in_use: str = "") -> str:
     """Return the name of the proposal file argument."""
     proposal_file_argname = (
         "--proposal-file"
-        if (consts.Eras[(command_era or "DEFAULT").upper()].value >= consts.Eras.CONWAY.value)
+        if (consts.Eras[era_in_use.upper()].value >= consts.Eras.CONWAY.value)
         else "--update-proposal-file"
     )
     return proposal_file_argname


### PR DESCRIPTION
- Replace string literals with constants from CommandEras class.
- Add error handling for unknown command eras.
- Update method signatures and internal logic to use era_in_use.
- Remove redundant command_era checks and arguments.
- Simplify proposal file argument name determination.