### PR TITLE
refactor: remove slots_offset and add dynamic calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,6 @@ The library needs working `cardano-cli` (the command is available on `PATH`, `ca
 cluster = clusterlib.ClusterLib(state_dir="path/to/cluster/state_dir")
 ```
 
-On custom testnets that were started in Byron era, you might need to specify a slots offset between Byron epochs and Shelley epochs.
-The "slots_offset" is a difference between number of slots in Byron epochs and in the same number of Shelley epochs.
-
-E.g. for a testnet with parameters
-
-* 100 slots per epoch in Byron era
-* 1000 slots per epoch in Shelley era
-* two epochs in Byron era before forking to Shelley
-
-The offset will be `2 * (1000 - 100) = 1800`.
-
-```python
-cluster = clusterlib.ClusterLib(state_dir="path/to/cluster/state_dir", slots_offset=1800)
-```
-
 ### Transfer funds
 
 ```python

--- a/cardano_clusterlib/clusterlib.py
+++ b/cardano_clusterlib/clusterlib.py
@@ -12,7 +12,6 @@ from cardano_clusterlib.consts import Eras
 from cardano_clusterlib.consts import MAINNET_MAGIC
 from cardano_clusterlib.consts import MultiSigTypeArgs
 from cardano_clusterlib.consts import MultiSlotTypeArgs
-from cardano_clusterlib.consts import SLOTS_OFFSETS
 from cardano_clusterlib.consts import ScriptTypes
 from cardano_clusterlib.consts import Votes
 from cardano_clusterlib.coverage import record_cli_coverage

--- a/cardano_clusterlib/clusterlib_helpers.py
+++ b/cardano_clusterlib/clusterlib_helpers.py
@@ -333,3 +333,17 @@ def wait_for_epoch(
 
     LOGGER.debug(f"Expected epoch started; epoch number: {this_epoch}")
     return this_epoch
+
+
+def get_slots_offset(clusterlib_obj: "itp.ClusterLib") -> int:
+    """Get offset of slots from Byron era vs current configuration."""
+    tip = clusterlib_obj.g_query.get_tip()
+    slot = int(tip["slot"])
+    slots_ep_end = int(tip["slotsToEpochEnd"])
+    epoch = int(tip["epoch"])
+
+    slots_total = slot + slots_ep_end
+    slots_shelley = int(clusterlib_obj.epoch_length) * (epoch + 1)
+
+    offset = slots_shelley - slots_total
+    return offset

--- a/cardano_clusterlib/consts.py
+++ b/cardano_clusterlib/consts.py
@@ -4,14 +4,6 @@ import typing as tp
 DEFAULT_COIN: tp.Final[str] = "lovelace"
 MAINNET_MAGIC: tp.Final[int] = 764824073
 
-# offset of slots from Byron configuration vs current era configuration
-SLOTS_OFFSETS: tp.Final[tp.Dict[int, int]] = {
-    764824073: 85363200,  # mainnet
-    1097911063: 30369600,  # testnet
-    1: 1641600,  # preprod
-}
-
-
 # The SUBCOMMAND_MARK is used to mark the beginning of a subcommand. It is used to differentiate
 # between options and subcommands. That is needed for CLI coverage recording.
 # For example, the command `cardano-cli query tx-mempool --cardano-mode info`


### PR DESCRIPTION
Removed the hardcoded slots_offset and replaced it with a dynamic calculation based on the current testnet configuration. This change improves flexibility and accuracy when dealing with different testnets in the Cardano blockchain.