### PR TITLE
feat: deprecate send_funds in favor of send_tx

### DIFF
--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -5,6 +5,7 @@ import json
 import logging
 import pathlib as pl
 import typing as tp
+import warnings
 
 from packaging import version
 
@@ -1563,6 +1564,11 @@ class TransactionGroup:
             structs.TxRawOutput: A tuple with transaction output details.
         """
         # pylint: disable=too-many-arguments
+        warnings.warn(
+            "`send_funds` is deprecated, use `send_tx` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.send_tx(
             src_address=src_address,
             tx_name=tx_name,


### PR DESCRIPTION
Added a warning to indicate that `send_funds` is deprecated and `send_tx` should be used instead. This change ensures that users are aware of the deprecation and can transition to the new method.