### PR TITLE
chore: update pre-commit hooks and fix imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     language_version: python3
@@ -13,7 +13,7 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.6.3
+  rev: v0.8.3
   hooks:
     - id: ruff
       args: [ --fix ]
@@ -23,7 +23,7 @@ repos:
   hooks:
   - id: shellcheck
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.41.0
+  rev: v0.43.0
   hooks:
   - id: markdownlint
 - repo: local

--- a/cardano_clusterlib/__init__.py
+++ b/cardano_clusterlib/__init__.py
@@ -4,6 +4,6 @@ from cardano_clusterlib.clusterlib_klass import ClusterLib
 from cardano_clusterlib.exceptions import CLIError
 
 __all__ = [
-    "ClusterLib",
     "CLIError",
+    "ClusterLib",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "I001", "ISC", "N", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
-ignore = ["D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PT001", "PT004", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
+ignore = ["D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PT001", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
- Bump pre-commit hooks versions in .pre-commit-config.yaml
- Reformat code with the new ruff
- Update ignore rules in pyproject.toml for ruff