### PR TITLE
fix(docs): pin documentation dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-Sphinx==7.4.7
-m2r2
-sphinx_rtd_theme
+Sphinx==8.1.3
+docutils==0.20.1
+m2r2==0.3.3.post2
+sphinx-rtd-theme==3.0.1


### PR DESCRIPTION
Updated Sphinx to version 8.1.3, m2r2 to version 0.3.3.post2, sphinx-rtd-theme to version 3.0.1, and added docutils version 0.20.1 to make builds more predictable.

Also fixes

```
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/cardano-clusterlib-py/envs/latest/lib/python3.10/site-packages/m2r2.py", line 611, in run
    path = nodes.reprunicode(path)
AttributeError: module 'docutils.nodes' has no attribute 'reprunicode'
```