### PR TITLE
feat: add confirm_blocks property to ClusterLib

### DIFF
--- a/cardano_clusterlib/clusterlib_klass.py
+++ b/cardano_clusterlib/clusterlib_klass.py
@@ -58,7 +58,9 @@ class ClusterLib:
             msg = f"Unknown command era `{command_era}`."
             raise exceptions.CLIError(msg) from excp
 
-        self.cluster_id = 0  # can be used for identifying cluster instance
+        self.cluster_id = 0  # Can be used for identifying cluster instance
+        # Number of new blocks before the Tx is considered confirmed
+        self.confirm_blocks = consts.CONFIRM_BLOCKS_NUM
         self.cli_coverage: dict = {}
         self._rand_str = helpers.get_rand_str(4)
         self._cli_log = ""

--- a/cardano_clusterlib/consts.py
+++ b/cardano_clusterlib/consts.py
@@ -3,6 +3,7 @@ import typing as tp
 
 DEFAULT_COIN: tp.Final[str] = "lovelace"
 MAINNET_MAGIC: tp.Final[int] = 764824073
+CONFIRM_BLOCKS_NUM: tp.Final[int] = 2
 
 # The SUBCOMMAND_MARK is used to mark the beginning of a subcommand. It is used to differentiate
 # between options and subcommands. That is needed for CLI coverage recording.

--- a/cardano_clusterlib/consts.py
+++ b/cardano_clusterlib/consts.py
@@ -24,15 +24,15 @@ class CommandEras:
 
 
 class Eras(enum.Enum):
-    BYRON: int = 1
-    SHELLEY: int = 2
-    ALLEGRA: int = 3
-    MARY: int = 4
-    ALONZO: int = 6
-    BABBAGE: int = 8
-    CONWAY: int = 9
-    DEFAULT: int = CONWAY
-    LATEST: int = CONWAY
+    BYRON = 1
+    SHELLEY = 2
+    ALLEGRA = 3
+    MARY = 4
+    ALONZO = 6
+    BABBAGE = 8
+    CONWAY = 9
+    DEFAULT = CONWAY
+    LATEST = CONWAY  # noqa: PIE796
 
 
 class MultiSigTypeArgs:
@@ -55,6 +55,6 @@ class ScriptTypes:
 
 
 class Votes(enum.Enum):
-    YES: int = 1
-    NO: int = 2
-    ABSTAIN: int = 3
+    YES = 1
+    NO = 2
+    ABSTAIN = 3

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -1154,7 +1154,7 @@ class TransactionGroup:
         return txhash
 
     def submit_tx(
-        self, tx_file: itp.FileType, txins: list[structs.UTXOData], wait_blocks: int = 2
+        self, tx_file: itp.FileType, txins: list[structs.UTXOData], wait_blocks: int | None = None
     ) -> str:
         """Submit a transaction, resubmit if the transaction didn't make it to the chain.
 
@@ -1166,6 +1166,11 @@ class TransactionGroup:
         Returns:
             str: A transaction ID.
         """
+        wait_blocks = (
+            self._clusterlib_obj.confirm_blocks
+            if wait_blocks is None or wait_blocks < 1
+            else wait_blocks
+        )
         txid = ""
         for r in range(20):
             err = None


### PR DESCRIPTION
- Added `confirm_blocks` property to `ClusterLib` class.
- Set default value for `CONFIRM_BLOCKS_NUM` in `consts.py`.
- Updated `submit_tx` method in `TransactionGroup` to use `confirm_blocks`.