### PR TITLE
chore: add build dependency to requirements-dev.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ lint:
 # build package
 .PHONY: build
 build:
-	if ! python3 -c "import build" >/dev/null 2>&1; then python3 -m pip install --upgrade build; fi
 	python3 -m build
 
 # upload package to PyPI

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@
 mypy
 pre-commit
 
+build
 virtualenv


### PR DESCRIPTION
Removed redundant build installation from Makefile and added it to requirements-dev.txt to ensure all dependencies are managed in one place.