### PR TITLE
refactor: remove pylint disable comments

### DIFF
--- a/cardano_clusterlib/clusterlib.py
+++ b/cardano_clusterlib/clusterlib.py
@@ -3,7 +3,6 @@
 Import everything that used to be available here for backwards compatibility.
 """
 
-# pylint: disable=unused-import
 # flake8: noqa
 from cardano_clusterlib.clusterlib_klass import ClusterLib
 from cardano_clusterlib.consts import CommandEras

--- a/cardano_clusterlib/clusterlib_klass.py
+++ b/cardano_clusterlib/clusterlib_klass.py
@@ -42,8 +42,6 @@ class ClusterLib:
         command_era: An era used for CLI commands, by default same as the latest network Era.
     """
 
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(
         self,
         state_dir: itp.FileType,
@@ -51,7 +49,6 @@ class ClusterLib:
         socket_path: itp.FileType = "",
         command_era: str = consts.CommandEras.LATEST,
     ):
-        # pylint: disable=too-many-statements
         try:
             self.command_era = getattr(consts.CommandEras, command_era.upper())
         except AttributeError as excp:

--- a/cardano_clusterlib/conway_gov_action_group.py
+++ b/cardano_clusterlib/conway_gov_action_group.py
@@ -145,7 +145,6 @@ class ConwayGovActionGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.ActionConstitution:
         """Create a constitution."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{action_name}_constitution.action"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -224,7 +223,6 @@ class ConwayGovActionGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.ActionInfo:
         """Create an info action."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{action_name}_info.action"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -280,7 +278,6 @@ class ConwayGovActionGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.ActionNoConfidence:
         """Create a no confidence proposal."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{action_name}_confidence.action"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -349,7 +346,6 @@ class ConwayGovActionGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.ActionUpdateCommittee:
         """Create or update a new committee proposal."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{action_name}_update_committee.action"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -425,7 +421,6 @@ class ConwayGovActionGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.ActionPParamsUpdate:
         """Create a protocol parameters update proposal."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{action_name}_pparams_update.action"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -492,7 +487,6 @@ class ConwayGovActionGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.ActionTreasuryWithdrawal:
         """Create a treasury withdrawal."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{action_name}_info.action"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -594,7 +588,6 @@ class ConwayGovActionGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.ActionHardfork:
         """Create a hardfork initiation proposal."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{action_name}_hardfork.action"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)

--- a/cardano_clusterlib/conway_gov_vote_group.py
+++ b/cardano_clusterlib/conway_gov_vote_group.py
@@ -81,7 +81,6 @@ class ConwayGovVoteGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.VoteCC:
         """Create a governance action vote for a commitee member."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{vote_name}_cc.vote"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -147,7 +146,6 @@ class ConwayGovVoteGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.VoteDrep:
         """Create a governance action vote for a DRep."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{vote_name}_drep.vote"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -212,7 +210,6 @@ class ConwayGovVoteGroup:
         destination_dir: itp.FileType = ".",
     ) -> structs.VoteSPO:
         """Create a governance action vote for an SPO."""
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{vote_name}_spo.vote"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)

--- a/cardano_clusterlib/query_group.py
+++ b/cardano_clusterlib/query_group.py
@@ -20,8 +20,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class QueryGroup:
-    # pylint: disable=too-many-public-methods
-
     def __init__(self, clusterlib_obj: "itp.ClusterLib") -> None:
         self._clusterlib_obj = clusterlib_obj
 

--- a/cardano_clusterlib/stake_address_group.py
+++ b/cardano_clusterlib/stake_address_group.py
@@ -353,7 +353,6 @@ class StakeAddressGroup:
         Returns:
             Path: A path to the generated certificate.
         """
-        # pylint: disable=too-many-arguments
         if not self._clusterlib_obj.conway_genesis:
             msg = "Conway governance can be used only with Command era >= Conway."
             raise exceptions.CLIError(msg)
@@ -433,7 +432,6 @@ class StakeAddressGroup:
         Returns:
             Path: A path to the generated certificate.
         """
-        # pylint: disable=too-many-arguments
         if not self._clusterlib_obj.conway_genesis:
             msg = "Conway governance can be used only with Command era >= Conway."
             raise exceptions.CLIError(msg)

--- a/cardano_clusterlib/structs.py
+++ b/cardano_clusterlib/structs.py
@@ -80,7 +80,7 @@ class TxOut:
 # List of `TxOut`s, empty list, or empty tuple
 OptionalTxOuts = list[TxOut] | tuple[()]
 # List of `UTXOData`s, empty list, or empty tuple
-OptionalUTXOData = list[UTXOData] | tuple[()]  # pylint: disable=invalid-name
+OptionalUTXOData = list[UTXOData] | tuple[()]
 
 
 @dataclasses.dataclass(frozen=True, order=True)

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -241,7 +241,6 @@ class TransactionGroup:
         Returns:
             structs.TxRawOutput: A tuple with transaction output details.
         """
-        # pylint: disable=too-many-arguments,too-many-branches,too-many-locals,too-many-statements
         if (treasury_donation is not None) != (current_treasury_value is not None):
             msg = (
                 "Both `treasury_donation` and `current_treasury_value` must be specified together."
@@ -475,7 +474,6 @@ class TransactionGroup:
         Returns:
             structs.TxRawOutput: A tuple with transaction output details.
         """
-        # pylint: disable=too-many-arguments
         destination_dir = pl.Path(destination_dir).expanduser()
         out_file = destination_dir / f"{tx_name}_tx.body"
         clusterlib_helpers._check_files_exist(out_file, clusterlib_obj=self._clusterlib_obj)
@@ -664,7 +662,6 @@ class TransactionGroup:
         Returns:
             int: An estimated fee.
         """
-        # pylint: disable=too-many-arguments
         tx_files = tx_files or structs.TxFiles()
         tx_name = f"{tx_name}_estimate"
 
@@ -836,7 +833,6 @@ class TransactionGroup:
         Returns:
             structs.TxRawOutput: A tuple with transaction output details.
         """
-        # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-branches
         max_txout = [o for o in txouts if o.amount == -1 and o.coin in ("", consts.DEFAULT_COIN)]
         if max_txout:
             if change_address:
@@ -1303,7 +1299,6 @@ class TransactionGroup:
         Returns:
             structs.TxRawOutput: A tuple with transaction output details.
         """
-        # pylint: disable=too-many-arguments
         tx_files = tx_files or structs.TxFiles()
 
         # Resolve withdrawal amounts here (where -1 for total rewards amount is used) so the
@@ -1549,7 +1544,6 @@ class TransactionGroup:
         Returns:
             List[dict]: A Plutus scripts cost data.
         """
-        # pylint: disable=too-many-arguments,unused-argument
         # Collect all arguments that will be passed to `build_tx`
         kwargs = locals()
         kwargs.pop("self", None)
@@ -1598,7 +1592,6 @@ class TransactionGroup:
         Returns:
             structs.TxRawOutput: A tuple with transaction output details.
         """
-        # pylint: disable=too-many-arguments
         warnings.warn(
             "`send_funds` is deprecated, use `send_tx` instead",
             DeprecationWarning,

--- a/cardano_clusterlib/txtools.py
+++ b/cardano_clusterlib/txtools.py
@@ -612,7 +612,6 @@ def _get_return_collateral_txout_args(txouts: structs.OptionalTxOuts) -> list[st
     txout_records = [
         f"{t.amount} {t.coin if t.coin != consts.DEFAULT_COIN else ''}".rstrip() for t in txouts
     ]
-    # pylint: disable=consider-using-f-string
     address_value = "{}+{}".format(txouts[0].address, "+".join(txout_records))
     txout_args = ["--tx-out-return-collateral", address_value]
 
@@ -662,8 +661,6 @@ def _get_tx_ins_outs(
         Tuple[list, list]: A tuple of list of transaction inputs and list of transaction
             outputs.
     """
-    # pylint: disable=too-many-arguments
-
     txouts_passed_db: dict[str, list[structs.TxOut]] = _organize_tx_ins_outs_by_coin(txouts)
     txouts_mint_db: dict[str, list[structs.TxOut]] = _organize_tx_ins_outs_by_coin(mint_txouts)
     outcoins_all = {consts.DEFAULT_COIN, *txouts_mint_db.keys(), *txouts_passed_db.keys()}
@@ -793,7 +790,6 @@ def collect_data_for_build(
     Returns:
         structs.DataForBuild: A tuple with data for build(-raw) commands.
     """
-    # pylint: disable=too-many-arguments
     tx_files = tx_files or structs.TxFiles()
 
     withdrawals, script_withdrawals, withdrawals_txouts = _get_withdrawals(
@@ -1027,7 +1023,6 @@ def _get_script_args(  # noqa: C901
     script_votes: structs.OptionalScriptVotes,
     for_build: bool = True,
 ) -> list[str]:
-    # pylint: disable=too-many-statements,too-many-branches
     grouped_args: list[str] = []
     collaterals_all = set()
 

--- a/cardano_clusterlib/types.py
+++ b/cardano_clusterlib/types.py
@@ -2,7 +2,6 @@ import pathlib as pl
 import typing as tp
 
 if tp.TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cardano_clusterlib.clusterlib_klass import ClusterLib  # noqa: F401
 
 FileType = str | pl.Path


### PR DESCRIPTION
Removed unnecessary pylint disable comments from various files in the cardano_clusterlib module. We no longer use pylint.