### PR TITLE
chore: update ruff-pre-commit to v0.9.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.8.3
+  rev: v0.9.2
   hooks:
     - id: ruff
       args: [ --fix ]


### PR DESCRIPTION
Updated the ruff-pre-commit hook version from v0.8.3 to v0.9.2 in the .pre-commit-config.yaml file to ensure compatibility with the latest features and fixes.