### PR TITLE
fix(makefile): update pytype command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 .PHONY: lint
 lint:
 	pre-commit run -a
-	if type pytype >/dev/null 2>&1; then pytype cardano_clusterlib; fi
+	if command -v pytype >/dev/null 2>&1; then pytype -k -j auto cardano_clusterlib; fi
 
 # build package
 .PHONY: build


### PR DESCRIPTION
Updated the Makefile to call pytype with '-k -j auto' options (continue on error and run checks in parallel).