### PR TITLE
feat: add optional pparams argument to deposit methods

### DIFF
--- a/cardano_clusterlib/query_group.py
+++ b/cardano_clusterlib/query_group.py
@@ -277,24 +277,24 @@ class QueryGroup:
             vote_delegation=vote_delegation,
         )
 
-    def get_address_deposit(self) -> int:
+    def get_address_deposit(self, pparams: dict[str, tp.Any] | None = None) -> int:
         """Return stake address deposit amount."""
-        pparams = self.get_protocol_params()
+        pparams = pparams or self.get_protocol_params()
         return pparams.get("stakeAddressDeposit") or 0
 
-    def get_pool_deposit(self) -> int:
+    def get_pool_deposit(self, pparams: dict[str, tp.Any] | None = None) -> int:
         """Return stake pool deposit amount."""
-        pparams = self.get_protocol_params()
+        pparams = pparams or self.get_protocol_params()
         return pparams.get("stakePoolDeposit") or 0
 
-    def get_drep_deposit(self) -> int:
+    def get_drep_deposit(self, pparams: dict[str, tp.Any] | None = None) -> int:
         """Return DRep deposit amount."""
-        pparams = self.get_protocol_params()
+        pparams = pparams or self.get_protocol_params()
         return pparams.get("dRepDeposit") or 0
 
-    def get_gov_action_deposit(self) -> int:
+    def get_gov_action_deposit(self, pparams: dict[str, tp.Any] | None = None) -> int:
         """Return governance action deposit amount."""
-        pparams = self.get_protocol_params()
+        pparams = pparams or self.get_protocol_params()
         return pparams.get("govActionDeposit") or 0
 
     def get_stake_distribution(self) -> dict[str, float]:

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -149,9 +149,9 @@ class TransactionGroup:
             return 0
 
         pparams = self._clusterlib_obj.g_query.get_protocol_params()
-        key_deposit = pparams.get("stakeAddressDeposit") or 0
-        pool_deposit = pparams.get("stakePoolDeposit") or 0
-        drep_deposit = pparams.get("dRepDeposit") or 0
+        key_deposit = self._clusterlib_obj.g_query.get_address_deposit(pparams=pparams)
+        pool_deposit = self._clusterlib_obj.g_query.get_pool_deposit(pparams=pparams)
+        drep_deposit = self._clusterlib_obj.g_query.get_drep_deposit(pparams=pparams)
 
         deposit = 0
         for cert in tx_files.certificate_files:


### PR DESCRIPTION
- Updated `get_address_deposit`, `get_pool_deposit`, `get_drep_deposit`, and `get_gov_action_deposit` methods in `query_group.py` to accept an optional `pparams` argument.
- Modified `transaction_group.py` to use the updated methods with `pparams` argument.