### PR TITLE
refactor(consts): remove unused legacy era constants

### DIFF
--- a/cardano_clusterlib/consts.py
+++ b/cardano_clusterlib/consts.py
@@ -14,11 +14,6 @@ SUBCOMMAND_MARK: tp.Final[str] = "SUBCOMMAND"
 
 
 class CommandEras:
-    SHELLEY: tp.Final[str] = "shelley"
-    ALLEGRA: tp.Final[str] = "allegra"
-    MARY: tp.Final[str] = "mary"
-    ALONZO: tp.Final[str] = "alonzo"
-    BABBAGE: tp.Final[str] = "babbage"
     CONWAY: tp.Final[str] = "conway"
     LATEST: tp.Final[str] = "latest"
 


### PR DESCRIPTION
Remove the legacy era constants (SHELLEY, ALLEGRA, MARY, ALONZO, BABBAGE) from the CommandEras class in consts.py. Only CONWAY and LATEST are now retained, reflecting current usage and simplifying the codebase.