### PR TITLE
fix(transaction_group): make witness_count argument required

### DIFF
--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -558,7 +558,7 @@ class TransactionGroup:
         txbody_file: itp.FileType,
         txin_count: int,
         txout_count: int,
-        witness_count: int = 1,
+        witness_count: int,
         byron_witness_count: int = 0,
         reference_script_size: int = 0,
     ) -> int:
@@ -568,7 +568,7 @@ class TransactionGroup:
             txbody_file: A path to file with transaction body.
             txin_count: A number of transaction inputs.
             txout_count: A number of transaction outputs.
-            witness_count: A number of witnesses (optional).
+            witness_count: A number of witnesses.
             byron_witness_count: A number of Byron witnesses (optional).
             reference_script_size: A size in bytes of transaction reference scripts (optional).
 


### PR DESCRIPTION
The `witness_count` parameter in the `TransactionGroup._estimate_tx_size` method is now required instead of having a default value. This change removes ambiguity and enforces explicit specification of the witness count when estimating transaction size.