### PR TITLE
feat(lint): add pyrefly and update linting configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,13 @@ repos:
   - id: markdownlint
 - repo: local
   hooks:
+  - id: pyrefly
+    name: pyrefly
+    entry: pyrefly
+    args: [ check, --remove-unused-ignores ]
+    pass_filenames: false
+    language: system
+    types: [python]
   - id: mypy
     name: mypy
     entry: mypy

--- a/cardano_clusterlib/clusterlib_klass.py
+++ b/cardano_clusterlib/clusterlib_klass.py
@@ -47,7 +47,7 @@ class ClusterLib:
         slots_offset: int | None = None,
         socket_path: itp.FileType = "",
         command_era: str = consts.CommandEras.LATEST,
-    ):
+    ) -> None:
         try:
             self.command_era = getattr(consts.CommandEras, command_era.upper())
         except AttributeError as excp:
@@ -59,6 +59,7 @@ class ClusterLib:
         self.confirm_blocks = consts.CONFIRM_BLOCKS_NUM
         self._rand_str = helpers.get_rand_str(4)
         self._cli_log = ""
+        # pyrefly: ignore  # missing-attribute
         self.era_in_use = (
             consts.Eras.__members__.get(command_era.upper()) or consts.Eras["DEFAULT"]
         ).name.lower()
@@ -100,6 +101,7 @@ class ClusterLib:
         # Conway+ era
         self.conway_genesis_json: pl.Path | None = None
         self.conway_genesis: dict = {}
+        # pyrefly: ignore  # bad-specialization, bad-argument-type, not-a-type
         if consts.Eras[self.era_in_use.upper()].value >= consts.Eras.CONWAY.value:
             # Conway genesis
             self.conway_genesis_json = clusterlib_helpers._find_conway_genesis_json(
@@ -276,6 +278,7 @@ class ClusterLib:
             if retcode == 0:
                 break
 
+            # pyrefly: ignore  # missing-attribute
             stderr_dec = stderr.decode()
             err_msg = (
                 f"An error occurred running a CLI command `{cmd_str}` on path "
@@ -289,6 +292,7 @@ class ClusterLib:
         else:
             raise exceptions.CLIError(err_msg)
 
+        # pyrefly: ignore  # bad-argument-type
         return structs.CLIOut(stdout or b"", stderr or b"")
 
     def refresh_pparams_file(self) -> None:

--- a/cardano_clusterlib/txtools.py
+++ b/cardano_clusterlib/txtools.py
@@ -1428,6 +1428,7 @@ def get_proposal_file_argname(era_in_use: str = "") -> str:
     """Return the name of the proposal file argument."""
     proposal_file_argname = (
         "--proposal-file"
+        # pyrefly: ignore  # bad-specialization, bad-argument-type, not-a-type
         if (consts.Eras[era_in_use.upper()].value >= consts.Eras.CONWAY.value)
         else "--update-proposal-file"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,11 @@ force_single_line = true
 line-length = 100
 
 [tool.ruff.lint]
-select = ["ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "FURB", "I001", "ISC", "N", "PERF", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
+select = ["ANN", "ARG", "B", "C4", "C90", "D", "DTZ", "E", "EM", "F", "FURB", "I001", "ISC", "N", "PERF", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "Q", "RET", "RSE", "RUF", "SIM", "TRY", "UP", "W", "YTT"]
 ignore = ["D10", "D203", "D212", "D213", "D214", "D215", "D404", "D405", "D406", "D407", "D408", "D409", "D410", "D411", "D413", "ISC001", "PLR0912", "PLR0913", "PLR0915", "PT001", "PT007", "PT012", "PT018", "PT023", "PTH123", "RET504", "TRY002", "TRY301", "UP006", "UP007", "UP035"]
+
+[tool.ruff.lint.per-file-ignores]
+"docs/**.py" = ["ANN"]
 
 [tool.ruff.lint.isort]
 force-single-line = true
@@ -56,6 +59,18 @@ ignore_missing_imports = true
 follow_imports = "normal"
 no_implicit_optional = true
 allow_untyped_globals = false
-allow_untyped_defs = false
 warn_unused_configs = true
 warn_return_any = true
+
+[tool.pyrefly]
+project_includes = ["cardano_clusterlib"]
+ignore_errors_in_generated_code = true
+use_untyped_imports = true
+ignore_missing_source = true
+
+[[tool.pyrefly.sub_config]]
+matches = "cardano_clusterlib/clusterlib_klass.py"
+
+# Ignore the bad-argument-type errors for Self@ClusterLib, that are reported only for LSP
+[tool.pyrefly.sub_config.errors]
+bad-argument-type = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,9 @@
 -e . --config-settings editable_mode=compat
 
 # linting
-mypy
-pre-commit
+mypy~=1.15.0
+pyrefly~=0.17.0
+pre-commit~=4.2.0
 
 build
 virtualenv


### PR DESCRIPTION
- Add pyrefly to pre-commit hooks and development requirements.
- Configure pyrefly in pyproject.toml with project-specific settings and per-file ignores.
- Update ruff linting rules to include ANN and add per-file ignore for docs.
- Pin mypy and pre-commit versions for consistency.
- Add pyrefly ignore comments in code to suppress specific errors.