### PR TITLE
refactor: use builtin generics for type hints in docstrings

### DIFF
--- a/cardano_clusterlib/helpers.py
+++ b/cardano_clusterlib/helpers.py
@@ -28,7 +28,7 @@ def _prepend_flag(flag: str, contents: itp.UnpackableSequence) -> list[str]:
         contents: A list (iterable) of content to be prepended.
 
     Returns:
-        List[str]: A list of flag followed by content, see below.
+        list[str]: A list of flag followed by content, see below.
 
     >>> ClusterLib._prepend_flag(None, "--foo", [1, 2, 3])
     ['--foo', '1', '--foo', '2', '--foo', '3']

--- a/cardano_clusterlib/query_group.py
+++ b/cardano_clusterlib/query_group.py
@@ -78,7 +78,7 @@ class QueryGroup:
             coins: A list (iterable) of coin names (asset IDs, optional).
 
         Returns:
-            List[structs.UTXOData]: A list of UTxO data.
+            list[structs.UTXOData]: A list of UTxO data.
         """
         cli_args = ["utxo", "--output-json"]
 
@@ -352,7 +352,7 @@ class QueryGroup:
                 epoch (current epoch by default)
 
         Returns:
-            List[structs.LeadershipSchedule]: A list of `structs.LeadershipSchedule`, specifying
+            list[structs.LeadershipSchedule]: A list of `structs.LeadershipSchedule`, specifying
                 slot and time.
         """
         args = []

--- a/cardano_clusterlib/stake_pool_group.py
+++ b/cardano_clusterlib/stake_pool_group.py
@@ -261,7 +261,7 @@ class StakePoolGroup:
             destination_dir: A path to directory for storing artifacts (optional).
 
         Returns:
-            Tuple[Path, structs.TxRawOutput]: A tuple with pool registration cert file and
+            tuple[Path, structs.TxRawOutput]: A tuple with pool registration cert file and
                 transaction output details.
         """
         tx_name = f"{tx_name}_reg_pool"
@@ -316,7 +316,7 @@ class StakePoolGroup:
             destination_dir: A path to directory for storing artifacts (optional).
 
         Returns:
-            Tuple[Path, structs.TxRawOutput]: A data container with pool registration cert file and
+            tuple[Path, structs.TxRawOutput]: A data container with pool registration cert file and
                 transaction output details.
         """
         tx_name = f"{tx_name}_dereg_pool"

--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -1872,7 +1872,7 @@ class TransactionGroup:
             destination_dir: A path to directory for storing artifacts (optional).
 
         Returns:
-            List[dict]: A Plutus scripts cost data.
+            list[dict]: A Plutus scripts cost data.
         """
         # Collect all arguments that will be passed to `build_tx`
         kwargs = locals()

--- a/cardano_clusterlib/txtools.py
+++ b/cardano_clusterlib/txtools.py
@@ -374,7 +374,7 @@ def _resolve_withdrawals(
         withdrawals: A list (iterable) of `TxOuts`, specifying reward withdrawals.
 
     Returns:
-        List[structs.TxOut]: A list of `TxOuts`, specifying resolved reward withdrawals.
+        list[structs.TxOut]: A list of `TxOuts`, specifying resolved reward withdrawals.
     """
     resolved_withdrawals = []
     for rec in withdrawals:
@@ -658,7 +658,7 @@ def _get_tx_ins_outs(
             (`build` command balance the assets automatically in newer versions).
 
     Returns:
-        Tuple[list, list]: A tuple of list of transaction inputs and list of transaction
+        tuple[list, list]: A tuple of list of transaction inputs and list of transaction
             outputs.
     """
     txouts_passed_db: dict[str, list[structs.TxOut]] = _organize_tx_ins_outs_by_coin(txouts)
@@ -863,7 +863,7 @@ def get_utxo(
         coins: A list (iterable) of coin names (asset IDs).
 
     Returns:
-        List[structs.UTXOData]: A list of UTxO data.
+        list[structs.UTXOData]: A list of UTxO data.
     """
     utxo = []
     for utxo_rec, utxo_data in utxo_dict.items():


### PR DESCRIPTION
Update type hints to use builtin generics (e.g., list, tuple) instead of capitalized versions (e.g., List, Tuple) in docstrings and return annotations. This improves consistency with modern Python typing conventions.