### PR TITLE
chore: update linting, CI, and dependencies

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -1,15 +1,16 @@
-name: repo_lint
+name: repo_tests
 
 on:
   pull_request:
     branches:
     - master
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   lint:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
@@ -17,9 +18,12 @@ jobs:
       id: setup-python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
-      run: make install
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        make install
     - name: Load cached pre-commit env
       id: cached-pre-commit
       uses: actions/cache@v4
@@ -30,6 +34,7 @@ jobs:
       run: |
         mkdir -p ~/.cache/pre-commit
         true > ~/.cache/pre-commit/pre-commit.log
+        source .venv/bin/activate
         pre-commit install-hooks --color=always
         retval="$?"
         if [ "$retval" -ne 0 ]; then
@@ -37,4 +42,6 @@ jobs:
         fi
         exit "$retval"
     - name: Run pre-commit linters
-      run: pre-commit run -a --show-diff-on-failure --color=always
+      run: |
+        source .venv/bin/activate
+        pre-commit run -a --show-diff-on-failure --color=always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,20 +12,6 @@ repos:
     language_version: python3
   - id: debug-statements
     language_version: python3
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.9.2
-  hooks:
-    - id: ruff
-      args: [ --fix ]
-    - id: ruff-format
-- repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.10.0.1
-  hooks:
-  - id: shellcheck
-- repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.43.0
-  hooks:
-  - id: markdownlint
 - repo: local
   hooks:
   - id: pyrefly
@@ -35,6 +21,22 @@ repos:
     pass_filenames: false
     language: system
     types: [python]
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.12.1
+  hooks:
+    - id: ruff-check
+      args: [ --fix ]
+    - id: ruff-format
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.10.0.1
+  hooks:
+  - id: shellcheck
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.45.0
+  hooks:
+  - id: markdownlint
+- repo: local
+  hooks:
   - id: mypy
     name: mypy
     entry: mypy

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,16 @@
 .PHONY: install
 install:
-	python3 -m pip install --upgrade pip
-	python3 -m pip install --upgrade wheel
-	python3 -m pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt $(PIP_INSTALL_ARGS)
-	virtualenv --upgrade-embed-wheels
+	python3 -m pip install --require-virtualenv --upgrade pip
+	python3 -m pip install --require-virtualenv --upgrade -r requirements-dev.txt $(PIP_INSTALL_ARGS)
 
 .PHONY: .install_doc
 .install_doc:
-	python3 -m pip install --upgrade --upgrade-strategy eager -r docs/requirements.txt
+	python3 -m pip install --require-virtualenv --upgrade -r docs/requirements.txt
 
 # run linters
 .PHONY: lint
 lint:
-	pre-commit run -a
+	pre-commit run -a --show-diff-on-failure --color=always
 	if command -v pytype >/dev/null 2>&1; then pytype -k -j auto cardano_clusterlib; fi
 
 # build package
@@ -23,7 +21,7 @@ build:
 # upload package to PyPI
 .PHONY: upload
 upload:
-	if ! type twine >/dev/null 2>&1; then python3 -m pip install --upgrade twine; fi
+	if ! command -v twine >/dev/null 2>&1; then python3 -m pip install --require-virtualenv --upgrade twine; fi
 	twine upload --skip-existing dist/*
 
 # release package to PyPI

--- a/cardano_clusterlib/clusterlib_klass.py
+++ b/cardano_clusterlib/clusterlib_klass.py
@@ -59,7 +59,7 @@ class ClusterLib:
         self.confirm_blocks = consts.CONFIRM_BLOCKS_NUM
         self._rand_str = helpers.get_rand_str(4)
         self._cli_log = ""
-        # pyrefly: ignore  # missing-attribute
+
         self.era_in_use = (
             consts.Eras.__members__.get(command_era.upper()) or consts.Eras["DEFAULT"]
         ).name.lower()
@@ -101,7 +101,7 @@ class ClusterLib:
         # Conway+ era
         self.conway_genesis_json: pl.Path | None = None
         self.conway_genesis: dict = {}
-        # pyrefly: ignore  # bad-specialization, bad-argument-type, not-a-type
+
         if consts.Eras[self.era_in_use.upper()].value >= consts.Eras.CONWAY.value:
             # Conway genesis
             self.conway_genesis_json = clusterlib_helpers._find_conway_genesis_json(

--- a/cardano_clusterlib/txtools.py
+++ b/cardano_clusterlib/txtools.py
@@ -22,9 +22,10 @@ def _organize_tx_ins_outs_by_coin(
     """Organize transaction inputs or outputs by coin type."""
     db: dict[str, list] = {}
     for rec in tx_list:
-        if rec.coin not in db:
-            db[rec.coin] = []
-        db[rec.coin].append(rec)
+        rc = rec.coin
+        if rc not in db:
+            db[rc] = []
+        db[rc].append(rec)
     return db
 
 
@@ -1428,7 +1429,6 @@ def get_proposal_file_argname(era_in_use: str = "") -> str:
     """Return the name of the proposal file argument."""
     proposal_file_argname = (
         "--proposal-file"
-        # pyrefly: ignore  # bad-specialization, bad-argument-type, not-a-type
         if (consts.Eras[era_in_use.upper()].value >= consts.Eras.CONWAY.value)
         else "--update-proposal-file"
     )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,10 +72,10 @@ html_static_path = ["_static"]
 if os.environ.get("CARDANO_CLUSTERLIB_GIT_REV"):
     cardano_clusterlib._git_rev = os.environ.get("CARDANO_CLUSTERLIB_GIT_REV")
 else:
-    p = subprocess.Popen(
+    with subprocess.Popen(
         ["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    stdout, __ = p.communicate()
+    ) as p:
+        stdout, __ = p.communicate()
     cardano_clusterlib._git_rev = stdout.decode().strip()
 if not cardano_clusterlib._git_rev:
     cardano_clusterlib._git_rev = "master"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
--e . --config-settings editable_mode=compat
+-e .
 
 # linting
-mypy~=1.15.0
-pyrefly~=0.17.0
+mypy~=1.16.1
+pyrefly~=0.22.0
 pre-commit~=4.2.0
 
 build


### PR DESCRIPTION
- Rename and update GitHub Actions workflow to `repo_tests`, using Python 3.12, venv, and improved pre-commit caching and activation.
- Update pre-commit config: bump ruff and markdownlint versions, move pyrefly hook, and update ruff hook id.
- Update Makefile to require virtualenv for pip installs and improve commands.
- Bump mypy and pyrefly versions in requirements-dev.txt.
- Minor code cleanups: remove obsolete pyrefly ignore comments, clarify variable names, and use context manager for subprocess in docs conf.py.