### PR TITLE
fix(build): update setuptools package discovery config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,9 @@ homepage = "https://github.com/input-output-hk/cardano-clusterlib-py"
 documentation = "https://cardano-clusterlib-py.readthedocs.io/"
 repository = "https://github.com/input-output-hk/cardano-clusterlib-py"
 
-[tool.setuptools]
-package-dir = {"" = "cardano_clusterlib"}
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["cardano_clusterlib*"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
Switch to setuptools 'packages.find' for package discovery in pyproject.toml. This ensures all cardano_clusterlib* packages are included correctly.