### PR TITLE
chore(makefile): remove redundant pytype lint step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ install:
 .PHONY: lint
 lint:
 	pre-commit run -a --show-diff-on-failure --color=always
-	if command -v pytype >/dev/null 2>&1; then pytype -k -j auto cardano_clusterlib; fi
 
 # build package
 .PHONY: build


### PR DESCRIPTION
The pytype command was removed from the lint target to streamline the linting process and avoid redundant type checking, as pre-commit hooks already handle code quality checks.