### PR TITLE
fix: recognize Dijkstra AllInputsAreSpent on resubmit

### DIFF
--- a/cardano_clusterlib/transaction_group.py
+++ b/cardano_clusterlib/transaction_group.py
@@ -1563,6 +1563,9 @@ class TransactionGroup:
                     exc_str = str(exc)
                     inputs_spent = (
                         '(ConwayMempoolFailure "All inputs are spent.' in exc_str
+                        # The Dijkstra era injects the Conway mempool failure above as its
+                        # own dedicated failure.
+                        or "(AllInputsAreSpent" in exc_str
                         or "(BadInputsUTxO" in exc_str
                     )
                     if not inputs_spent:


### PR DESCRIPTION
The Dijkstra era injects the Conway `ConwayMempoolFailure "All inputs are spent."` as its own dedicated `AllInputsAreSpent` failure. Without it in the checked error variants, `submit_tx` raised instead of waiting for a Tx that had already made it to the chain.