### PR TITLE
fix(lint): run mypy as single pre-commit process

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,12 @@ repos:
     entry: mypy
     language: system
     types: [python]
+    # Run mypy once on all sources instead of letting pre-commit shard the files
+    # over parallel processes. mypy 2.x enables the SQLite cache by default,
+    # and concurrent processes sharing `.mypy_cache` fail to acquire its lock:
+    # `sqlite3.OperationalError: database is locked` surfaces as an intermittent
+    # mypy `INTERNAL ERROR`. Sharding is also slower, as every shard re-analyzes
+    # the full dependency graph.
+    pass_filenames: false
+    require_serial: true
+    args: [cardano_clusterlib, docs/source/conf.py]


### PR DESCRIPTION
The local mypy hook passed filenames without `require_serial`, so pre-commit sharded the Python files across one process per CPU.

mypy 2.x defaults `sqlite_cache` to True, and concurrent processes sharing `.mypy_cache` then contend for the SQLite lock: `sqlite3.OperationalError: database is locked` is unhandled and reported as an `INTERNAL ERROR`. The pinned mypy 1.19.1 still uses the filesystem cache backend and tolerates this, so the hook only breaks once mypy is bumped to 2.x.

Sharding is also wasteful, as every shard re-analyzes the whole dependency graph.

Set `pass_filenames: false` and `require_serial: true`, and pass the source paths explicitly. `types: [python]` still gates the hook on a Python file having changed.